### PR TITLE
[CRITICAL] Fix command injection in library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+
 "use strict";
 
 var cp = require( 'child_process' ),
@@ -73,37 +74,47 @@ module.exports = {
             // Append it to the temporary file
             fs.appendFileSync( that.tempFile, content );
         });
+        const command = "markdown_py";
 
         // Now, everything is correctly added in the temp file,
         // so we can transform everything with markdown_py.
-        // For this, we need to build up the command.
-        var command = "markdown_py --output_format='html5' ";
-
+		// For this, we need to build up the command.
+		var command_args = [];
+		command_args.push("--output_format=html5")
         if ( this.toc ) {
-            command += '-x toc ';
+			command_args.push('-x');
+			command_args.push('toc');
         }
         if ( this.table ) {
-            command += '-x table ';
-        }
+			command_args.push('-x');
+			command_args.push('table');
+		}
+		
+		command_args.push(this.tempFile);
+		var outputStream = fs.createWriteStream(this.output);
+		var writeError = null;
+		outputStream.on('error', function(err) {
+			writeError = err;
+		});
 
-        command += this.tempFile + ' ';
-
-        command += '> ' + this.output;
-
-        // Execute the command
-        cp.exec( command, function( err, stdout, stderr ) {
+		var markdown_py = cp.execFile(command, command_args, function( err, stdout, stderr ) {
             if ( err ) throw err;
-
-            // Append the header
-
+			
+			outputStream.write(stdout);
+			if ( writeError )
+			{
+				console.log(`'\nFailed to write to \u001b[32m${that.output}\u001b[0m\n'`);
+				fs.unlinkSync( that.tempFile );
+				return;
+			}
             // Now append a little string to the generated file
-            fs.appendFileSync( that.output, getFoot.bind( that )() );
+            outputStream.write(getFoot.bind( that )() );
 
             // Delete the temporary file
             fs.unlinkSync( that.tempFile );
 
             console.log( '\nDocumentation generated at \u001b[32m' + that.output + '\u001b[0m\n' );
-        });
+		})
     }
 };
 


### PR DESCRIPTION
This solution fixes the command injection in the library by utilizing `execFile` instead of  `exec`  and by building the arguments in an array.